### PR TITLE
Make documentation consistent with current state of STIM

### DIFF
--- a/notebooks/openst_example.ipynb
+++ b/notebooks/openst_example.ipynb
@@ -1098,7 +1098,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "st.bdv_view3d(container=container_path,\n",
+    "st.bdv_view3d(input=container_path,\n",
     "              genes=hvg_genes)"
    ]
   },

--- a/notebooks/visium_example.ipynb
+++ b/notebooks/visium_example.ipynb
@@ -304,7 +304,7 @@
       },
       "outputs": [],
       "source": [
-        "st.explorer(container=container_path,\n",
+        "st.explorer(input=container_path,\n",
         "            datasets=sections)"
       ]
     },
@@ -405,7 +405,7 @@
       },
       "outputs": [],
       "source": [
-        "st.bdv_view3d(container=container_path,\n",
+        "st.bdv_view3d(input=container_path,\n",
         "              genes=['Calm2', 'Mbp'])"
       ]
     },
@@ -466,7 +466,7 @@
         "# iterate over datasets and apply the computed transformation\n",
         "for z_axis, dataset_name in zip(sections_numbers, container.get_dataset_names()):\n",
         "    with container.get_dataset(dataset_name, mode=\"r+\") as dataset:\n",
-        "        dataset.apply_save_transform(transformation=\"model_sift\",\n",
+        "        dataset.apply_save_transform(transformation=\"transform\",\n",
         "                                     locations='spatial',\n",
         "                                     destination='spatial_transform_sift',\n",
         "                                     z_coord=z_axis)"

--- a/stimwrap/_stim_functions.py
+++ b/stimwrap/_stim_functions.py
@@ -399,7 +399,7 @@ def align_pairs_add(
 # alignment
 @stim_function("st-align-interactive")
 def align_interactive(
-    input: str,
+    container: str,
     section_a: str,
     section_b: str,
     num_genes: int = 10,
@@ -466,7 +466,7 @@ def align_interactive(
         validate_positive(ff_single_spot)
 
     args = [
-        f"--input {input}",
+        f"--container {container}",
         f"--dataset1 {section_a}",
         f"--dataset2 {section_b}",
         f"--numGenes {num_genes}",


### PR DESCRIPTION
Just a few changes of argument names to make it compatible with the current version of the STIM package (which is the version that will be published on conda).